### PR TITLE
Googleでの画像検索用リンクを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ dmypy.json
 cython_debug/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+
+*.png

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,15 +2,10 @@
 {% block content %}
 <div class="ui center aligned segment">
     <h1>フォント判定</h1>
-    <form
-        class="ui action input"
-        action="/upload"
-        method="post"
-        enctype="multipart/form-data"
-        onsubmit="onloading()"
-    >
-        <input type="file" name="image" required="required"　accept="image/png, image/jpeg">
-        <input type="number" name="display_num" required="required"　maxlength="2" value="5" placeholder="表示する候補数" step="1">
+    <form class="ui action input" action="/upload" method="post" enctype="multipart/form-data" onsubmit="onloading()">
+        <input type="file" name="image" required="required" 　accept="image/png, image/jpeg">
+        <input type="number" name="display_num" required="required" 　maxlength="2" value="5" placeholder="表示する候補数"
+            step="1">
         <button type="submit" class="ui button">submit</button>
     </form>
 </div>
@@ -20,26 +15,30 @@
     <h1>過去に判定されたフォント集</h1>
     <div class="ui link centered cards">
         {% for path in images %}
+        {% if path != ".gitkeep" %}
+        <!-- フォント名は、ファイル名の_までに格納されているので、_までを抽出している -->
+        {% set img_name = path[:path.find('_')] %}
         <!-- ref: https://semantic-ui.com/views/card.html -->
-        <div class="card">
+        <a class="card" href="https://www.google.com/search?q={{ img_name }}">
             <div class="image">
                 <img src="/static/images/{{ path }}">
             </div>
             <div class="content">
                 <div class="description">
-                    {{ path[:path.find('_')] }}
+                    {{ img_name }}
                 </div>
             </div>
-        </div>
+        </a>
+        {% endif %}
         {% endfor %}
     </div>
 </div>
 {% endif %}
 
 <script type="text/javascript">
-function onloading() {
-    document.querySelector('div').className += ' loading';
-}
+    function onloading() {
+        document.querySelector('div').className += ' loading';
+    }
 </script>
 
 {% endblock %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -4,7 +4,8 @@
   {% if fonts_data_response.ok %}
     <div class="ui relaxed list">
     {% for font_data in fonts_data_response.fonts_data %}
-    <div class="item">{{ loop.index }}番目: {{ font_data.name }} ({{ (font_data.probability * 100.0)|round(2, 'floor') }}%) </div>  
+    <div class="item">{{ loop.index }}番目: {{ font_data.name }} ({{ (font_data.probability * 100.0)|round(2, 'floor') }}%) </div>
+    <a href="https://www.google.com/search?q={{ font_data.name }}">フォントの詳細</a>
     {% endfor %}
     </div>
   <a href="./">トップへ戻る</a>


### PR DESCRIPTION
## 概要
- Googleでの画像検索用リンクを、一覧ページと検索結果ページに追加しました
   - 画像のプレビューを表示したかったのですが、プレビューのためにフォントをロードすると処理が遅くなるので断念しました

## なぜ必要なのか
- ユーザはフォント名を与えられた時に、どのようなフォントか確認したくなると思ったため

closes #24 