### PR TITLE
Internal Server Errorの原因となっていたディレクトリを追加

### DIFF
--- a/server.py
+++ b/server.py
@@ -26,6 +26,13 @@ class FontsDataResponse:
 
 
 SAVE_DIR = "./static/images"
+# ディレクトリがなかったら作成するコードを追加
+try:
+    if not os.path.exists(SAVE_DIR):
+        os.makedirs(SAVE_DIR)
+except Exception as e:
+    print(e)
+
 img=0
 
 @app.route('/')

--- a/static/images/.gitkeep
+++ b/static/images/.gitkeep
@@ -1,0 +1,3 @@
+# DO NOT DELETE!
+# このファイルは絶対に消さないで
+# このファイルを消すとディレクトリが消えてInternal Server Errorになるので


### PR DESCRIPTION
## 概要
Internal Server Errorの原因となっていたディレクトリを追加
- SAVE_DIRが存在しない場合にindex()で落ちる

## なぜ必要なのか
Internal Server Errorになるとトップページが見えないため

closes #48